### PR TITLE
Allow Edits to be done on the website

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,5 +37,6 @@ module.exports = {
     '@next/next/no-img-element': 'off',
     'react/no-unescaped-entities': 'off',
     'react/jsx-closing-tag-location': 'error',
+	"prettier/prettier": ["error", { "endOfLine": "off" }],
   },
 };


### PR DESCRIPTION
This is part of a larger plan to improve the website and the curating experience. By allowing edits to be done in the website, you no longer have to fork the repository, make an edit to the large manifest file, optionally run the site in developer mode to make sure it's valid, then upload the changes to your own repository on another branch, and then, and only then be able to get it merged in. You can now just edit the parts and fields you want and submit them and they'll be automatically sent off to be reviewed, and then merged in.

Right now I still have to manually copy the manifest over from the other repository, but this can be automated in the future.