### PR TITLE
Fix missing comma in games.json

### DIFF
--- a/games.json
+++ b/games.json
@@ -597,7 +597,7 @@
         "name": "Widespread reports of anticheat breaking following November 16th 2023 update",
         "date": "Nov 16, 2023, 07:24 PM GMT+1",
         "reference": "https://www.reddit.com/r/linux_gaming/comments/17wtqu1/hunt_showdown_not_working_anymore/"
-      }
+      },
       {
         "name": "Anticheat appears to be fixed following the official acknowledgment of anticheat issues by Crytek.",
         "date": "Nov 23, 2023, 11:54 UTC",


### PR DESCRIPTION
This PR fixes a missing comma in the `"updates"` section for "Hunt: Showdown", making the JSON valid again. I tested parsing with Python's `json` library before and after this patch, and it parses successfully with this patch. 

Not sure if this list is auto-generated, but there is a missing comma in this list, which can break downstream services parsing `games.json` such as ProtonUp-Qt.

Thanks :-)