### PR TITLE
Remove invalid comma in games.json

### DIFF
--- a/games.json
+++ b/games.json
@@ -3916,7 +3916,7 @@
     "notes": [],
     "updates": [],
     "storeIds": {
-      "steam": "985810",
+      "steam": "985810"
     },
     "slug": "grandchase"
   },


### PR DESCRIPTION
A trailing comma in the JSON in this position isn't valid in some parsers, such as with the Python `json` module. This error was introduced in #1502. I'm not sure if this file is automatically generated anywhere, but if not, this should be the only thing required to fix it.

```py
>>> import json
>>> with open('games.json') as f:
...     json.load(f)
... 
Traceback (most recent call last):
  File "<input>", line 2, in <module>
    json.load(f)
  File "/usr/lib/python3.11/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 3920 column 5 (char 89952)
```