### PR TITLE
Update Battlefield V

### DIFF
--- a/games.json
+++ b/games.json
@@ -3939,7 +3939,12 @@
       "FairFight",
       "EA anticheat"
     ],
-    "notes": [],
+    "notes": [
+      [
+        "No longer works due to the implementation of EA Anticheat",
+        ""
+      ]
+    ],
     "updates": [],
     "storeIds": {
       "steam": "1238810",

--- a/games.json
+++ b/games.json
@@ -3933,10 +3933,11 @@
     "name": "Battlefield V",
     "logo": "",
     "native": false,
-    "status": "Supported",
+    "status": "Denied",
     "reference": "https://www.protondb.com/app/1238810",
     "anticheats": [
-      "FairFight"
+      "FairFight",
+      "EA anticheat"
     ],
     "notes": [],
     "updates": [],


### PR DESCRIPTION
On April 3rd 2024, EA anticheat was added to Battlefield V. 

Currently, if you try to launch the game using Proton, you get an error saying `Wine not supported`

