### PR TITLE
games: Add Splitgate 2

### DIFF
--- a/games.json
+++ b/games.json
@@ -8931,5 +8931,28 @@
     ],
     "storeIds": {},
     "dateChanged": "2024-08-21T20:57:30.623Z"
+  },
+  {
+    "url": "https://splitgate.com",
+    "slug": "splitgate-2",
+    "name": "Splitgate 2",
+    "logo": "",
+    "native": false,
+    "status": "Broken",
+    "reference": "",
+    "anticheats": [
+      "EQU8"
+    ],
+    "updates": [],
+    "notes": [
+      [
+        "Unreleased, Anticheat broken in closed alpha",
+        null
+      ]
+    ],
+    "storeIds": {
+      "steam": "2918300"
+    },
+    "dateChanged": "2024-08-22T05:58:13.928Z"
   }
 ]


### PR DESCRIPTION
After trying to playtest the alpha, EQU8 fails when trying to load the game through Proton with the error "Unable to start the game process".

The Splitgate Discord server has Steam Deck roles, but I wouldn't expect AC support until release.