### PR TITLE
update games: fortnite removed battleye

### DIFF
--- a/games.json
+++ b/games.json
@@ -55,7 +55,6 @@
     "status": "Denied",
     "reference": "",
     "anticheats": [
-      "BattlEye",
       "Easy Anti-Cheat"
     ],
     "notes": [

--- a/games.json
+++ b/games.json
@@ -78,6 +78,11 @@
         "name": "Was running for a short period of time",
         "date": "Nov 2, 2022, 8:04 AM GMT+1",
         "reference": "https://github.com/Starz0r/AreWeAntiCheatYet/issues/918#issuecomment-1299673303"
+      },
+      {
+        "name": "Removed BattlEye",
+        "date": "Jun 11, 2024, 5:34 PM GMT+1",
+        "reference": "https://x.com/ShiinaBR/status/1800567329870537171"
       }
     ],
     "storeIds": {
@@ -87,7 +92,7 @@
       }
     },
     "slug": "fortnite",
-    "dateChanged": "2024-01-22T17:23:46.000Z"
+    "dateChanged": "2024-10-04T17:23:46.000Z"
   },
   {
     "url": "",


### PR DESCRIPTION
Epic has removed BattlEye from Fortnite

Does not change its status, it still is Denied.

(proof, there is no longer a battleye folder or the battleye exe)
![image](https://github.com/user-attachments/assets/37775113-1ecb-4b79-b9ae-f7bf3c6c9663)
![image](https://github.com/user-attachments/assets/4196c6cd-f65f-40aa-9d0d-91ff81108030)
![image](https://github.com/user-attachments/assets/9e6eb42a-6c3a-4185-82c1-7f126fdb9a8a)
