### PR TITLE
Remove Concord from Games

### DIFF
--- a/games.json
+++ b/games.json
@@ -8166,27 +8166,6 @@
   },
   {
     "url": "",
-    "slug": "concord",
-    "name": "Concord",
-    "logo": "",
-    "native": false,
-    "status": "Denied",
-    "reference": "",
-    "anticheats": [
-      "Easy Anti-Cheat"
-    ],
-    "updates": [],
-    "notes": [
-      [
-        "Unreleased, explictly unsupported in the Open Beta",
-        null
-      ]
-    ],
-    "storeIds": {},
-    "dateChanged": "2024-08-25T21:58:42.016Z"
-  },
-  {
-    "url": "",
     "slug": "bleeding-edge",
     "name": "Bleeding Edge",
     "logo": "",


### PR DESCRIPTION
This is removing concord just to tidy up the list, it's been shut down for a long while. https://en.wikipedia.org/wiki/Concord_(video_game) As of october 29th, 2024. 