### PR TITLE
games: Update Watch_dogs 2 status to Running, added Steam storeid

### DIFF
--- a/games.json
+++ b/games.json
@@ -1590,7 +1590,7 @@
     "name": "Watch_Dogs® 2",
     "logo": "",
     "native": false,
-    "status": "Broken",
+    "status": "Running",
     "reference": "",
     "anticheats": [
       "Easy Anti-Cheat"
@@ -1598,13 +1598,14 @@
     "notes": [],
     "updates": [],
     "storeIds": {
+      "steam": "447040"
       "epic": {
         "namespace": "angelonia",
         "slug": "watch-dogs-2"
       }
     },
     "slug": "watch-dogs-2",
-    "dateChanged": "2024-10-13T20:19:23.668Z"
+    "dateChanged": "2025-07-30T04:26:00.000Z"
   },
   {
     "url": "",


### PR DESCRIPTION
Change game's status to Running, added Steam storeid.

This is based on protondb reports and my test on uplay version through lutris.

Some more info behind this:

At game's main menu, there will be a error message complains EAC not installed, but it's actually up and running.

This game's EAC client performs DNS query and tried to connect these 2 domains of EAC server:

```
hydra.easyanticheat.net
cerberus-front.easyanticheat.net
```

Which have CNAME record redirects to:

```
gamesec-hydra-eu-lb-prod-220534806.eu-west-1.elb.amazonaws.com
gamesec-cerberus-eu-lb-prod-2faf4367b7ffd912.elb.eu-west-1.amazonaws.com
```

Both of them got NXDOMAIN response from DNS provider for unknown reason.

By looking into this game's EAC log file: `drive_c/users/user/Documents/My Games/Watch_Dogs 2/EAC.log`

`[EasyAntiCheat,WARNING] [EAC Internal]: [Register Client] No back-end connection! Reporting Client( 0000000000000001 ) as authenticated.`

It seems this game's EAC still lets you connect to game server despite cannot connect to EAC server.