### PR TITLE
Update for Exoborne, The Crew Motorfest

### DIFF
--- a/games.json
+++ b/games.json
@@ -13239,17 +13239,28 @@
     "name": "The Crew™ Motorfest",
     "logo": "",
     "native": false,
-    "status": "Broken",
+    "status": "Supported",
     "reference": "",
     "anticheats": [
       "BattlEye"
     ],
-    "updates": [],
+    "updates": [
+      {
+        "name": "Running on Proton",
+        "date": "Jun 5, 2025, 0:00 AM GMT",
+        "reference": "https://www.protondb.com/app/2698940#nICRHhtT8P"
+      },
+      {
+        "name": "Officially supported",
+        "date": "Oct 30, 2025, 0:00 AM GMT",
+        "reference": "https://www.ubisoft.com/en-us/game/the-crew/motorfest/news-updates/35DPcha72DbvZFcSFkHP28/season-8-quality-of-life-improvements"
+      }
+	],
     "notes": [],
     "storeIds": {
       "steam": "2698940"
     },
-    "dateChanged": "2024-10-18T17:04:48.773188-05:00"
+    "dateChanged": "2025-10-30T04:00:00.000Z"
   },
   {
     "url": "",
@@ -14773,16 +14784,18 @@
       "Easy Anti-Cheat",
       "AnyBrain"
     ],
-    "updates": [],
-    "notes": [
-      [
-        "Unreleased"
-      ]
-    ],
+    "updates": [
+	  {
+        "name": "Denied in playtest",
+        "date": "Sep 18, 2025, 0:00 AM GMT",
+        "reference": "https://imgur.com/a/znTffem"
+      }
+	],
+    "notes": [],
     "storeIds": {
       "steam": "2705130"
     },
-    "dateChanged": "2024-11-11T06:05:11.460Z"
+    "dateChanged": "2025-10-30T04:00:000Z"
   },
   {
     "url": "",

--- a/games.json
+++ b/games.json
@@ -14767,17 +14767,16 @@
     "name": "Exoborne",
     "logo": "",
     "native": false,
-    "status": "Broken",
-    "reference": "",
+    "status": "Denied",
+    "reference": "https://imgur.com/a/jTz3mId",
     "anticheats": [
-      "Anti-Cheat Expert",
+      "Easy Anti-Cheat",
       "AnyBrain"
     ],
     "updates": [],
     "notes": [
       [
-        "Unreleased, Speculative",
-        null
+        "Unreleased"
       ]
     ],
     "storeIds": {


### PR DESCRIPTION
Exoborne: Adjust anticheats based on steamDB depots info (cannot found ACE in depot history but EAC instead). Set status to Denied with reference.

TCM: Set status to Supported, added updates message.