### PR TITLE
Fix anti-cheat engine name for Sniper Elite: Resistance

### DIFF
--- a/games.json
+++ b/games.json
@@ -21817,7 +21817,7 @@
     "status": "Running",
     "reference": "",
     "anticheats": [
-      "Denuvo",
+      "Denuvo Anti-Cheat",
 	  "Easy Anti-Cheat"
     ],
     "updates": [],


### PR DESCRIPTION
All the other games with Denuvo Anti-Cheat call it "Denuvo Anti-Cheat", but this game entry had it listed as just "Denuvo", which meant there was an entry for Denuvo on the summary part of the website stating "Denuvo" had just 1 game in the list.