### PR TITLE
Add sourcing for skate. (url, reference, notes, storeIds)

### DIFF
--- a/games.json
+++ b/games.json
@@ -21480,19 +21480,30 @@
     "dateChanged": "2025-11-08T23:40:22.0000000-05:00"
   },
   {
-    "url": "",
+    "url": "https://store.steampowered.com/app/3354750/",
     "slug": "skate.",
     "name": "skate.",
     "logo": "",
     "native": false,
     "status": "Denied",
-    "reference": "",
+    "reference": "https://www.gamingonlinux.com/2025/09/full-circle-ea-confirm-again-that-skate-will-not-support-linux-steam-deck-or-macos/",
     "anticheats": [
       "EA anticheat"
     ],
     "updates": [],
-    "notes": [],
-    "storeIds": {},
+    "notes": [
+      [
+        "Earlier report: skate. unsupported on Linux/SteamOS/Deck due to anti-cheat (July 2025)",
+        "https://www.gamingonlinux.com/2025/07/the-upcoming-skate-from-ea-will-be-unsupported-on-linux-steamos-and-steam-deck-due-to-anti-cheat/"
+      ],
+      [
+        "Proton compatibility report confirming this is an anti-cheat restriction, not a Proton bug",
+        "https://github.com/ValveSoftware/Proton/issues/10108"
+      ]
+    ],
+    "storeIds": {
+      "steam": "3354750"
+    },
     "dateChanged": "2025-12-11T00:11:04.0000000-05:00"
   },
   {


### PR DESCRIPTION
Adds sourcing for the existing `skate.` entry (added in #1873, status
`Denied` since 2025-12-11). No status change — `Denied` is correct.

This fills the previously empty `url`, `reference`, `notes` and `storeIds`
fields:

- `url`: Steam store page (appid 3354750)
- `reference`: Full Circle/EA's public confirmation (GamingOnLinux,
September 2025) that skate. will not support Linux, Steam Deck or macOS
- `notes`: an earlier GamingOnLinux report (July 2025) on the same
restriction, plus a Proton compatibility report
(ValveSoftware/Proton#10108) documenting the E111000B block from the
player side
- `storeIds.steam`: 3354750

Happy to adjust field names/format to match the current contribution
template if this differs from what's shown here.