### PR TITLE
Update games.json with wardogs

### DIFF
--- a/games.json
+++ b/games.json
@@ -21996,5 +21996,28 @@
     ],
     "storeIds": {},
     "dateChanged": "2025-12-17T12:21:49.197311-05:00"
+  },
+  {
+    "url": "",
+    "slug": "wardogs",
+    "name": "WARDOGS",
+    "logo": "",
+    "native": false,
+    "status": "Broken",
+    "reference": "",
+    "anticheats": [
+      "Elytra"
+    ],
+    "updates": [],
+    "notes": [
+      [
+        "Unreleased, on and off Broken in playtest, prior to Elytra, when using EAC",
+        null
+      ]
+    ],
+    "storeIds": {
+      "steam": "1867240"
+	},
+    "dateChanged": "2026-09-02T12:17:00.000000Z"
   }
 ]


### PR DESCRIPTION
Update games.json with wardogs, closes issue #1942

date-changed was set to date and time of the patch that changed the AC to Elytra off of the former EAC.
slug set to lowercase of the name, hopefully acceptable

I assumed based on other games AC's not having webp files, and no entries for elytra, it would be fine to enter it in without a specific name.

I didn't see a contributing.md file, so I tried to reverse engineer the existing games in the json. Feel free to make edits as needed.